### PR TITLE
Fix build warnings and bump version

### DIFF
--- a/logstash-filter-cipher.gemspec
+++ b/logstash-filter-cipher.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-cipher'
-  s.version         = '0.1.5'
+  s.version         = '0.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter parses a source and apply a cipher or decipher before storing it in the target"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '~> 0', '>= 0.0.15'
 end
 


### PR DESCRIPTION
Now:

```
# gem build logstash-filter-cipher.gemspec                                                                                                     <<<
  Successfully built RubyGem
  Name: logstash-filter-cipher
  Version: 0.1.6
  File: logstash-filter-cipher-0.1.6.gem
```

vs:

```
# gem build logstash-filter-cipher.gemspec
WARNING:  open-ended dependency on logstash-devutils (>= 0, development) is not recommended
  if logstash-devutils is semantically versioned, use:
    add_development_dependency 'logstash-devutils', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: logstash-filter-cipher
  Version: 0.1.5
  File: logstash-filter-cipher-0.1.5.gem
```
